### PR TITLE
resize 복원 및 계산식 수정

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,8 +15,10 @@ async def get_image_size_test(image: UploadFile = File(...)):
     except Exception:
         return ErrorResponse(400, "잘못된 이미지입니다.")
     
-
-    rvec, dist, fx, fy, cx, cy = box.calculate_camera_parameters(image)
+    try:
+        rvec, dist, fx, fy, cx, cy = box.calculate_camera_parameters(image)
+    except Exception:
+        return ErrorResponse(400, "인식되지않았습니다. 다시 시도해주세요.")
 
     params = {
         "rvec": rvec.tolist(),

--- a/main.py
+++ b/main.py
@@ -2,23 +2,63 @@ from fastapi import FastAPI, File, UploadFile, Form
 from fastapi.responses import JSONResponse
 from PIL import Image
 from modules import box
-
+import json
+import numpy as np
 
 app = FastAPI()
 
-@app.post("/api/analyze-1")
-async def get_image_size(image: UploadFile = File(...),
-                         width: int = Form(...),
-                         height: int = Form(...),
-                         focalLength: float = Form(...)):
+@app.post("/api/test")
+async def get_image_size_test(image: UploadFile = File(...)):
     
     try:
         image = Image.open(image.file) # 이미지 객체 받아오기
     except Exception:
         return ErrorResponse(400, "잘못된 이미지입니다.")
     
+
+    rvec, dist, fx, fy, cx, cy = box.calculate_camera_parameters(image)
+
+    params = {
+        "rvec": rvec.tolist(),
+        "dist": dist.tolist(),
+        "fx": fx,
+        "fy": fy,
+        "cx": cx,
+        "cy": cy
+    }
+
+    # print(json.dumps(params))
+# rvec, dist, fx, fy, cx, cy
+    return {
+            "status": 200,
+            "response": {
+                "params" : params
+            },
+            "errorMessage": None
+        }
+
+def ErrorResponse(status, message):
+    return JSONResponse(status_code=status, content=
+                            {
+                                "status": status,
+                                "response": None,
+                                "errorMessage": message
+                            })
+
+@app.post("/api/analyze-1")
+async def get_image_size1(image: UploadFile = File(...), params : str = File(...)):
     try:
-        width, height, tall = box.calculate_box_size(image, width, height, focalLength)
+        image = Image.open(image.file) # 이미지 객체 받아오기
+    except Exception:
+        return ErrorResponse(400, "잘못된 이미지입니다.")
+    try:    
+        params_dict = json.loads(params)
+        params_list = [np.array(params_dict["rvec"]), np.array(params_dict["dist"]), params_dict["fx"], params_dict["fy"], params_dict["cx"], params_dict["cy"]]
+    except Exception:
+        return ErrorResponse(400, "/api/test 결과의 params를 그대로 돌려주세요")
+
+    try:
+        width, height, tall = box.calculate_box_size(image, params_list)
     except Exception:
         width, height, tall = 0, 0, 0
 
@@ -33,10 +73,7 @@ async def get_image_size(image: UploadFile = File(...),
         }
 
 @app.post("/api/analyze-2")
-async def get_image_size(image: UploadFile = File(...),
-                         width: int = Form(...),
-                         height: int = Form(...),
-                         focalLength: float = Form(...)):
+async def get_image_size2(image: UploadFile = File(...)):
     
     try:
         image = Image.open(image.file) # 이미지 객체 받아오기
@@ -44,7 +81,10 @@ async def get_image_size(image: UploadFile = File(...),
         return ErrorResponse(400, "잘못된 이미지입니다.")
     
 
-    width, height, tall = box.calculate_box_size(image, width, height, focalLength)
+    try:
+        width, height, tall = box.calculate_box_size(image)
+    except Exception:
+        width, height, tall = 0, 0, 0
 
     return {
         "status": 200,

--- a/modules/box.py
+++ b/modules/box.py
@@ -12,7 +12,7 @@ import numpy as np
 import cv2
 from modules import detector, simplifier, findDot, calibration
 
-def calculate_box_size(image : Image, width : int, height : int, focalLength : float):
+def calculate_box_size(image : Image, params, show=False):
 
     image = np.array(image)   # image를 cv2에서 사용 가능하게 변환
     image = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
@@ -21,9 +21,9 @@ def calculate_box_size(image : Image, width : int, height : int, focalLength : f
 
     box, original_ratio = simplifier.simplify(box) #배경 지우고, 외곽선 검출
 
-    w, h, t = findDot.find(box, image, xyxy, original_ratio, show=True)  #점 찾고 길이 반환 (show=True 시 과정 이미지 보임)
+    w, h, t = findDot.find(box, image, xyxy, original_ratio, params, show=show)  #점 찾고 길이 반환 (show=True 시 과정 이미지 보임)
 
-    print(w,h,t)
+    print("최종 계산 결과 w, h, t:", w,h,t)
 
     return w, h, t
 
@@ -33,10 +33,11 @@ def calculate_camera_parameters(image : Image):
     #print(rvec, dist, fx, fy, cx, cy, sep="\n")
 
     #TODO : 어떤 방식으로 서버에 저장할 지 정하기.
-    import pickle
-    paramFile = open("modules/params.bin",'wb')
-    pickle.dump(params, paramFile)
-    paramFile.close()
+    return params
+    # import pickle
+    # paramFile = open("modules/params.bin",'wb')
+    # pickle.dump(params, paramFile)
+    # paramFile.close()
 
 
 
@@ -50,5 +51,6 @@ if __name__ == '__main__':
     image = Image.open("modules/images_cali/st2.jpg") # 이미지 테스트
     image_cali = Image.open("modules/images_cali/check2.jpg") #calibration
 
-    calculate_camera_parameters(image_cali)
-    calculate_box_size(image,800,600,1)
+    params = calculate_camera_parameters(image_cali)
+    print("calculate_camera_parameters 결과:", params)
+    calculate_box_size(image, params, show=True)

--- a/modules/box.py
+++ b/modules/box.py
@@ -19,9 +19,9 @@ def calculate_box_size(image : Image, width : int, height : int, focalLength : f
 
     box, xyxy = detector.detect(image) #박스 감지하고 crop 리턴
 
-    box = simplifier.simplify(box) #배경 지우고 외곽선 검출
+    box, original_ratio = simplifier.simplify(box) #배경 지우고, 외곽선 검출
 
-    w, h, t = findDot.find(box, image, xyxy)  #점 찾고 길이 반환 (show=True 시 과정 이미지 보임)
+    w, h, t = findDot.find(box, image, xyxy, original_ratio, show=True)  #점 찾고 길이 반환 (show=True 시 과정 이미지 보임)
 
     print(w,h,t)
 
@@ -47,7 +47,7 @@ def show(img):
     cv2.waitKey()
 
 if __name__ == '__main__':
-    image = Image.open("modules/images_cali/test.jpg") # 이미지 테스트
+    image = Image.open("modules/images_cali/st2.jpg") # 이미지 테스트
     image_cali = Image.open("modules/images_cali/check2.jpg") #calibration
 
     calculate_camera_parameters(image_cali)

--- a/modules/findDot.py
+++ b/modules/findDot.py
@@ -178,18 +178,20 @@ def calculate_real_length(width, height, tall, distance, fx, img_width):
 
     return real_width, real_height, real_tall
 
-def adjust_points(top, bottom, left_top, left_bottom, right_top, right_bottom, away_x, away_y, original, edges, box):
+def adjust_points(top, bottom, left_top, left_bottom, right_top, right_bottom, away_y, original_ratio, box):
 
     points = [top, bottom, left_top, left_bottom, right_top, right_bottom]
     new_points = []
+    x_ratio = ((box[0][2] - box[0][0])/original_ratio[0])
+    y_ratio = ((box[0][3] - box[0][1])/original_ratio[1])
     for point in points:
-        new_points.append((point[0] + box[0][0], point[1] + box[0][1]))
+        new_points.append((box[0][0] + point[0] * x_ratio, box[0][1] + point[1] * y_ratio - (away_y * y_ratio)))
 
     return new_points[0], new_points[1], new_points[2], new_points[3], new_points[4], new_points[5]
 
 
 
-def find(edges, original, box, show=False):
+def find(edges, original, box, original_ratio, show=False):
 
     #카메라 파라미터를 구함
     import pickle
@@ -212,11 +214,10 @@ def find(edges, original, box, show=False):
 
     top, bottom, left_top, left_bottom, right_top, right_bottom = classify_points(points)
     #좌표 원본이미지에 맞게 보정
-    away_x, away_y = min(left_top[0], left_bottom[0]), top[1]
-    print(away_x, away_y)
 
     #좌표 조정
-    top, bottom, left_top, left_bottom, right_top, right_bottom = adjust_points(top, bottom, left_top, left_bottom, right_top, right_bottom, away_x, away_y, original, edges,box)
+    away_x, away_y = min(left_top[0], left_bottom[0]), top[1]
+    top, bottom, left_top, left_bottom, right_top, right_bottom = adjust_points(top, bottom, left_top, left_bottom, right_top, right_bottom, away_y, original_ratio ,box)
     
     if(show):
         new_points = [top, bottom, left_top, left_bottom, right_top, right_bottom]

--- a/modules/findDot.py
+++ b/modules/findDot.py
@@ -74,7 +74,7 @@ def calc_pixel_w_h(top, bottom, left_top, left_bottom, right_top, right_bottom, 
             math.sqrt((right_top[0] - right_bottom[0])**2 + (right_top[1] - right_bottom[1])**2)) / 2
     h_ratio = height / width
     t_ratio = tall / width
-    print(width, h_ratio, t_ratio)
+    print("(calc_pixel_w_h)width, h_ratio, t_ratio:", width, h_ratio, t_ratio)
     return 100 * diagonal * bottom_ratio, 100 * h_ratio * diagonal * bottom_ratio, 100 * t_ratio * diagonal * bottom_ratio, width
 
 def calc_diagonal(left_bottom, right_top):
@@ -206,13 +206,13 @@ def adjust_points(top, bottom, left_top, left_bottom, right_top, right_bottom, a
 
 
 
-def find(edges, original, box, original_ratio, show=False):
+def find(edges, original, box, original_ratio, params, show=False):
 
     #카메라 파라미터를 구함
-    import pickle
-    paramFile = open("modules/params.bin",'rb')
-    params = pickle.load(paramFile)   # tuple: (rvec, dist, fx, fy, cx, cy)
-    paramFile.close()
+    # import pickle
+    # paramFile = open("modules/params.bin",'rb')
+    # params = pickle.load(paramFile)   # tuple: (rvec, dist, fx, fy, cx, cy)
+    # paramFile.close()
 
     fx, fy, cx, cy = params[2:]
     dist = params[1]
@@ -249,7 +249,7 @@ def find(edges, original, box, original_ratio, show=False):
 
     #이미지 꼭지점 좌표를 토대로 구한 가로, 세로, 높이
     width, height, tall, img_width = calc_pixel_w_h(top, bottom, left_top, left_bottom, right_top, right_bottom, diagonal, bottom_ratio)
-    print(width, height, tall)
+    print("이미지 꼭지점 좌표를 토대로 구한 가로, 세로, 높이:", width, height, tall)
     
     #외부 파라미터 추정
     _retval, _rvec, tvec = calculate_parameters(fx, fy, cx, cy, dist, top, bottom, left_top, left_bottom, right_top, right_bottom, width, height, tall)
@@ -284,7 +284,7 @@ def find(edges, original, box, original_ratio, show=False):
         plt.show()
 
     distance = calculate_distance(rvec, tvec, bottom, fx, fy, cx, cy)
-    print(distance)
+    print("distance:", distance)
 
     w, h, t = calculate_real_length(width, height, tall, distance, fx, img_width, diagonal, bottom_ratio)
     #TODO: 길이 상수값 나중에 실험 후 확인

--- a/modules/findDot.py
+++ b/modules/findDot.py
@@ -7,7 +7,7 @@ import math
 실제 계산
 1. crop한 이미지 상의 좌표를 구함
 2. 원본 사진으로 좌표 이동
-3. 이미지 상의 상자 크기 구하기(이때, 상자 크기 정규화로 3D상에 표현, width=100으로 산정)
+3. 이미지 상의 상자 크기 구하기(이때, 상자 크기 정규화로 3D상에 표현, width=100으로 산정 후 대각선 길이와 이미지 밑부분으로 부터의 거리 곱)
 4. 초점거리, 원본사진의 중점, 2D좌표, 이미자 상의 박스 크기를 이용해 임의로 정한 3D좌표를 이용해 카메라 외부 파라미터(rvec, tvec)을 구함
 5. Rodrigues(rvec)으로 진짜 카메라 정보를 얻은 후, 실제 월드 좌표계의 박스 한 점과, 카메라의 좌표를 구한후 둘 사이 거리 구함
 6. 카메라 초점거리 : 실제 카메라와 물체간 거리 = 이미지 상 박스 크기 : 실제 박스크기 비례식을 이용해 박스 크기 산출
@@ -81,11 +81,15 @@ def calc_diagonal(left_bottom, right_top):
     return math.sqrt((left_bottom[0] - right_top[0])**2 + (left_bottom[1] - right_top[1])**2) / 100
 
 def linear_interpolation(top, bottom, original):
+    #top과 bottom을 이은 직선의 기울기
     inclination = (bottom[1] - top[1]) / (top[0] - bottom[0])
+    #그 직선이 이미지 바닥에 닿는 점 x좌표
     x_bottom = (original.shape[0] - bottom[1] + (inclination * bottom[0])) / inclination
     image_bottom = (x_bottom, original.shape[0])
+    #그 직선이 이미지 상단에 닿는 점 x좌표
     x_top = (0 - bottom[1] + (inclination * bottom[0])) / inclination
     image_top = (x_top, 0)
+    #바닥~bottom 거리 / 바닥~상단 거리 = 바닥으로부터 거리 비율
     bottom_ratio = math.sqrt((image_bottom[0] - bottom[0])**2 + (image_bottom[1] - bottom[1])**2) / math.sqrt((image_top[0] - image_bottom[0])**2 + (image_top[1] - image_bottom[1]))
     return bottom_ratio
 

--- a/modules/simplifier.py
+++ b/modules/simplifier.py
@@ -5,11 +5,13 @@ from rembg import remove
 def simplify(input):
     '''이미지의 배경을 제거하고 외곽선을 검출'''
     
-    '''
+    
     def resize_ratio(pic):
         size=(256, 256)
+        #덮어씌울 base_pic 생성
         base_pic=np.zeros((size[1],size[0]),np.uint8)
         pic1=pic
+        #원본 사진 비율 보존
         h,w=pic1.shape[:2]
         ash=size[1]/h
         asw=size[0]/w
@@ -20,11 +22,11 @@ def simplify(input):
         pic1 = cv2.resize(pic1,dsize=sizeas)
         base_pic[int(size[1]/2-sizeas[1]/2):int(size[1]/2+sizeas[1]/2),
         int(size[0]/2-sizeas[0]/2):int(size[0]/2+sizeas[0]/2)]=pic1
-        return base_pic '''
+        return base_pic, sizeas
 
 
     input = cv2.cvtColor(input, cv2.COLOR_BGR2GRAY) #흑백배경으로 변경
-    #input = resize_ratio(input)  #사이즈 변경?
+    input, original_ratio = resize_ratio(input)  #사이즈 변경?
 
 
     # 명암비 alpha 0이면 그대로, 양수일수록 명암비가 커진다.
@@ -44,5 +46,4 @@ def simplify(input):
     kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (3,3))
     # 커널을 사용해 MORPH_CLOSE -> 커널에 맞게 주변 픽셀 다 선택해서 채우기 때문에 선이 두꺼워진다.
     morphology = cv2.morphologyEx(nuki, cv2.MORPH_CLOSE, kernel)
-
-    return morphology
+    return morphology, original_ratio


### PR DESCRIPTION
## Summary
누끼가 제대로 따지지 않는 문제점을 해결하기 위해, (256, 256)으로 복원하는 resize작업을 다시 넣었고, 거기서 얻은 좌표값을 원본 사진에도 적용시키는데 성공했습니다.
계산식 또한, 카메라와 거리가 다른 동일한 크기의 물체에 대해 오차범위 +- 4cm 이내로 적용시켰고, 카메라와 거리가 같으나 크기가 다른 물체에 대해서도 실제 크기와 오차범위 +- 4cm 이내로 적용시켰습니다.
## Description
누끼따기는 주석 처리한 resize_ratio 함수를 복원시키고, 정사각형으로 resize 전인 비율을 반환값에 추가해서, 실제 상자크기 비율에 맞게 조정되게 계산했습니다. detecter에서 감지한 최하단 좌표 + 꼭지점 검출로 나온 점 좌표 * (원본 과 resize의 비율)
계산식은 left_bottom ~ right_top 간의 거리(diagonal)과, 이미지상 최하단 부분과 bottom 좌표가 떨어진 비율을 100에다 곱해줘서 정규화 과정을 진행했고, 이에 따라 길이 상수 또한 계산으로 나온 실제 크기 / 1.6 으로 수정해서 진행했습니다.
## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: #N/A
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->
